### PR TITLE
Added pluralize/singularize functions based on an int count.

### DIFF
--- a/library/src/main/kotlin/com/cesarferreira/pluralize/Pluralize.kt
+++ b/library/src/main/kotlin/com/cesarferreira/pluralize/Pluralize.kt
@@ -30,6 +30,20 @@ fun String.singularize(plurality: Plurality = Plurality.Plural): String {
     return this.singularize()
 }
 
+fun String.pluralize(count: Int): String {
+    if (count > 1)
+        return this.pluralize(Plurality.Plural)
+    else
+        return this.pluralize(Plurality.Singular)
+}
+
+fun String.singularize(count: Int): String {
+    if (count > 1)
+        return this.singularize(Plurality.Plural)
+    else
+        return this.singularize(Plurality.Singular)
+}
+
 private fun String.pluralizer(): String {
     if (unCountable().contains(this)) return this
     val rule = pluralizeRules().last { Pattern.compile(it.component1(), Pattern.CASE_INSENSITIVE).matcher(this).find() }


### PR DESCRIPTION
``` kotlin
"person".pluralize(1)  # => "person"
"person".pluralize(2)  # => "people"
```

That was needed.

Additionally, you might want to look at [Plural.kt](https://gist.github.com/ethauvin/7ed3c3ef3b56e47b27dbf6153da0d7d9). It might be a useful generic pattern.

Ultimately, I'd like to see the patterns, etc. included in resources instead of hard-coded. That will make it a lot easier for people to add/modify rules, and use the library with other languages. Have you looked at [Quantity Strings](https://developer.android.com/guide/topics/resources/string-resource.html#Plurals)?

Hope this helps,

E.
